### PR TITLE
Add interoperability with Windows OS

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,12 @@ var crypto = require('crypto')
 var EventEmitter = require('events').EventEmitter
 var fs = require('fs')
 var path = require('path')
+var npmPath = require('npm-path')
 var os = require('os')
 var spawn = require('child_process').spawn
 var Step = require('step')
 
-var PATH = process.env.PATH
+var PATH = npmPath.PATH
 
 var emitter
 
@@ -177,7 +178,7 @@ function clone(args, baseDir, privKey, cb) {
 }
 
 function addPath(str) {
-  PATH = PATH + ":" + str
+  PATH = PATH + npmPath.SEPARATOR + str
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,18 @@
   "description": "Easy Node.JS Git wrapper with support for SSH keys",
   "version": "0.3.1",
   "homepage": "https://github.com/niallo/Gitane",
-  "keywords":["git", "ssh", "strider"],
+  "keywords": [
+    "git",
+    "ssh",
+    "strider"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/niallo/Gitane.git"
   },
   "main": "index.js",
   "dependencies": {
+    "npm-path": "^1.0.1",
     "step": "~0.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
`PATH` is named `Path` on Windows, also, the `PATH` separator is different.
`npm-path` nicely abstracts these issues away for us

For reference: https://github.com/Strider-CD/strider-git/issues/23