### PR TITLE
Regex match to respect quotes in command arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ function run(baseDir, privKey, cmd, keyMode, cb) {
     }
   }
 
-  var split = cmd.split(/\s+/)
+  var split = cmd.match(/"[^"]+"|'[^']+'|\S+/g)
   var cmd = split[0]
   var args = split.slice(1)
 


### PR DESCRIPTION
When executing a command via `gitane.run` which has a quoted argument with spaces (for example: `git commit -m "Initial commit"`) the quotes were not respected and were being passed as separate args to the spawned process. This regex (h/t https://stackoverflow.com/a/29656458/1978435) splits args and respects quotes.