### PR TITLE
Allow commands with args to be passed as arrays of strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,9 +115,16 @@ function run(baseDir, privKey, cmd, keyMode, cb) {
     }
   }
 
-  var split = cmd.match(/"[^"]+"|'[^']+'|\S+/g)
-  var cmd = split[0]
-  var args = split.slice(1)
+  var args;
+  if (Array.isArray(cmd)) {
+    args = cmd.slice(1);
+    cmd = cmd[0];
+  }
+  else {
+    var split = cmd.match(/"[^"]+"|'[^']+'|\S+/g)
+    cmd = split[0]
+    args = split.slice(1)
+  }
 
   Step(
     function() {


### PR DESCRIPTION
Still supports commands passed as a single string as well.

This further improves the behavior enabled by the string-splitting regex because that regex still can fall flat for some corner cases with weirdly escaped quotes etc.